### PR TITLE
Added readable values

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -41,17 +41,17 @@ function Modal({ state, close }: ModalProps) {
             <p>
               Cases:
               {' '}
-              {state.cases}
+              {(state.cases || 0).toLocaleString('en-US')}
             </p>
             <p>
               Deaths:
               {' '}
-              {state.deaths}
+              {(state.deaths || 0).toLocaleString('en-US')}
             </p>
             <p>
               Suspects:
               {' '}
-              {state.suspects}
+              {(state.suspects || 0).toLocaleString('en-US')}
             </p>
           </div>
         </ModalContainer>

--- a/src/pages/Home/Popup.tsx
+++ b/src/pages/Home/Popup.tsx
@@ -24,17 +24,17 @@ function Popup({ hoveredState, styles, popupRef }: PopupProps) {
           <p>
             Cases:
             {' '}
-            {cases}
+            {(cases || 0).toLocaleString('en-US')}
           </p>
           <p>
             Deaths:
             {' '}
-            {deaths}
+            {(deaths || 0).toLocaleString('en-US')}
           </p>
           <p>
             Suspects:
             {' '}
-            {suspects}
+            {(suspects || 0).toLocaleString('en-US')}
           </p>
         </div>
       </PopupContainer>


### PR DESCRIPTION
I added the `toLocaleString` method to make numeric values ​​more readable.

Example:

![Screenshot_7](https://user-images.githubusercontent.com/53842126/152541680-4b8deca2-3bc4-4607-8848-1f5454a98782.png)
